### PR TITLE
bootstrap-sassのバージョンを3.4.1以上に指定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'annotate'
 gem 'bcrypt', '~> 3.1.12'
-gem 'bootstrap-sass', '~> 3.3.7'
+gem 'bootstrap-sass', '>= 3.4.1'
 gem 'bootstrap-will_paginate', '~> 1.0.0'
 gem 'carrierwave', '~> 1.2.2'
 gem 'coffee-rails', '~> 4.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,13 +45,13 @@ GEM
     ansi (1.5.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.4.7)
+    autoprefixer-rails (9.4.8)
       execjs
     bcrypt (3.1.12)
     bindex (0.5.0)
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     bootstrap-will_paginate (1.0.0)
       will_paginate
     builder (3.2.3)
@@ -81,7 +81,7 @@ GEM
     execjs (2.7.0)
     faker (1.7.3)
       i18n (~> 0.5)
-    ffi (1.10.0)
+    ffi (1.9.25)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
     flamegraph (0.9.5)
@@ -277,7 +277,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.1.0)
+    json (2.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -391,6 +391,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.0)
+      ffi (~> 1.9.6)
+      rake
     shellany (0.0.1)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -443,7 +446,7 @@ PLATFORMS
 DEPENDENCIES
   annotate
   bcrypt (~> 3.1.12)
-  bootstrap-sass (~> 3.3.7)
+  bootstrap-sass (>= 3.4.1)
   bootstrap-will_paginate (~> 1.0.0)
   bullet
   byebug (~> 9.0.6)


### PR DESCRIPTION
CVE-2019-8331 More information
moderate severity
Vulnerable versions: >= 3.0.0, < 3.4.1
Patched version: 3.4.1
In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/